### PR TITLE
feat: extend playersOrder type to include dartsElo

### DIFF
--- a/src/components/LeaderboardModal.bs.mjs
+++ b/src/components/LeaderboardModal.bs.mjs
@@ -17,7 +17,7 @@ function LeaderboardModal(props) {
       });
   var setOrder = match[1];
   var order = match[0];
-  var players = Players.useAllPlayers("elo", order);
+  var players = Players.useAllPlayers(gameMode === "Darts" ? "dartsElo" : "elo", order);
   var position = {
     contents: 0
   };

--- a/src/components/LeaderboardModal.res
+++ b/src/components/LeaderboardModal.res
@@ -1,7 +1,10 @@
 @react.component
 let make = (~show, ~setShow, ~gameMode, ~setGameMode) => {
   let (order, setOrder) = React.useState(_ => true)
-  let players = Players.useAllPlayers(~orderBy=#elo, ~asc=order)
+  let players = Players.useAllPlayers(
+    ~orderBy=gameMode == Games.Darts ? #dartsElo : #elo,
+    ~asc=order,
+  )
 
   let position = ref(0)
   let previousScore = ref(0)

--- a/src/helpers/Players.res
+++ b/src/helpers/Players.res
@@ -104,7 +104,7 @@ let addPlayer = async name => {
   ref
 }
 
-type playersOrder = [#games | #elo]
+type playersOrder = [#games | #elo | #dartsElo]
 
 // let sortPlayersBy(orderBy: playersOrder)
 

--- a/src/helpers/Players.resi
+++ b/src/helpers/Players.resi
@@ -27,7 +27,7 @@ type player = {
   dartsLastGames: array<int>,
 }
 
-type playersOrder = [#games | #elo]
+type playersOrder = [#games | #elo | #dartsElo]
 
 @inline
 let bucket: string


### PR DESCRIPTION
### Pull Request Description

**Title:** feat: extend playersOrder type to include dartsElo

**Description:**
This pull request introduces an enhancement to the `playersOrder` type by adding support for sorting players based on their `dartsElo`. The `LeaderboardModal` has been updated to conditionally utilize either `dartsElo` or the traditional `elo` depending on the selected game mode. 

These changes aim to improve the player sorting functionality specifically for Darts games, thereby enhancing the overall user experience. 

**Changes Made:**
- Extended the `playersOrder` type to include `dartsElo`.
- Updated the `Modal` to support conditional sorting based on game mode.

This update expected to provide a more tailored experience for users engaged in Darts allowing for better performance tracking and comparison among players.