### PR TITLE
fix: update player stats to use dartsElo instead of elo

### DIFF
--- a/src/components/DartsGameModeStep.bs.mjs
+++ b/src/components/DartsGameModeStep.bs.mjs
@@ -99,10 +99,10 @@ function DartsGameModeStep(props) {
           return roundedPoints;
         });
     await Promise.all(match[0].map(async function (player) {
-              return Players.updateDartsGameStats(player.key, 1, player.elo);
+              return Players.updateDartsGameStats(player.key, 1, player.dartsElo);
             }));
     await Promise.all(match[1].map(async function (player) {
-              return Players.updateDartsGameStats(player.key, 0, player.elo);
+              return Players.updateDartsGameStats(player.key, 0, player.dartsElo);
             }));
     await Stats.updateDartsStats();
     await sendUpdate(roundedPoints, DartsGames.dartsModeToString(Core__Option.getOr(dartMode, "Unknown")));

--- a/src/components/DartsGameModeStep.res
+++ b/src/components/DartsGameModeStep.res
@@ -78,13 +78,13 @@ let make = (~selectedUsers, ~setStep, ~reset, ~setEarnedPoints, ~players, ~gameM
 
     let _ = await Promise.all(
       Array.map(winners, async player => {
-        Players.updateDartsGameStats(player.key, 1, player.elo)
+        Players.updateDartsGameStats(player.key, 1, player.dartsElo)
       }),
     )
 
     let _ = await Promise.all(
       Array.map(losers, async player => {
-        Players.updateDartsGameStats(player.key, 0, player.elo)
+        Players.updateDartsGameStats(player.key, 0, player.dartsElo)
       }),
     )
 


### PR DESCRIPTION
### Pull Request Description

This pull request addresses an important update to the player statistics logic within the game. The key changes include:

- **Modification of Player Stats Calculation**: The logic for updating player statistics has been revised to utilize the `dartsElo` property instead of the previously used `elo`. This change applies to both winners and losers in the game mode.

- **Improved Accuracy**: By using the `dartsElo`, we ensure that the Elo ratings are specific to darts, which enhances the accuracy of player performance tracking.

These changes are crucial for maintaining the integrity of player statistics and ensuring that the performance metrics reflect the true skill levels of the players involved. 

Please review the changes and provide any feedback or approval for merging.