### PR TITLE
Fix Elo calculation in admin recalculate function

### DIFF
--- a/src/helpers/Stats.bs.mjs
+++ b/src/helpers/Stats.bs.mjs
@@ -187,7 +187,20 @@ async function recalculateStats() {
               match$1[2]
             ];
           }
-          match[0].forEach(function (player) {
+          var redPlayers$1 = match[1];
+          var bluePlayers$1 = match[0];
+          var match$2;
+          if (blueWin) {
+            match$2 = Elo.calculateScore(bluePlayers$1, redPlayers$1, "Foosball");
+          } else {
+            var match$3 = Elo.calculateScore(redPlayers$1, bluePlayers$1, "Foosball");
+            match$2 = [
+              match$3[1],
+              match$3[0],
+              match$3[2]
+            ];
+          }
+          match$2[0].forEach(function (player) {
                 var lastGames = Players.getLastGames(player.lastGames, blueWin);
                 var newrecord = Caml_obj.obj_dup(player);
                 newrecord.lastGames = lastGames;
@@ -202,7 +215,7 @@ async function recalculateStats() {
                 newrecord.wins = blueWin ? player.wins + 1 | 0 : player.wins;
                 players[player.key] = newrecord;
               });
-          match[1].forEach(function (player) {
+          match$2[1].forEach(function (player) {
                 var lastGames = Players.getLastGames(player.lastGames, redWin);
                 var newrecord = Caml_obj.obj_dup(player);
                 newrecord.lastGames = lastGames;

--- a/src/helpers/Stats.res
+++ b/src/helpers/Stats.res
@@ -189,6 +189,22 @@ let recalculateStats = async () => {
         (blue, red, points)
       }
     }
+    
+    // Also calculate Elo for foosball games (for legacy compatibility)
+    let (blueElo, redElo, _) = switch blueWin {
+    | true => Elo.calculateScore(bluePlayers, redPlayers, ~gameMode=Games.Foosball)
+    | false => {
+        let (red, blue, points) = Elo.calculateScore(
+          redPlayers,
+          bluePlayers,
+          ~gameMode=Games.Foosball,
+        )
+        (blue, red, points)
+      }
+    }
+    
+    let bluePlayers = blueElo
+    let redPlayers = redElo
     Array.forEach(bluePlayers, player => {
       let lastGames = Players.getLastGames(player.lastGames, blueWin)
       Dict.set(


### PR DESCRIPTION
## Summary
- Fix admin recalculate button not updating Elo ratings for foosball games
- Add Elo calculation alongside OpenSkill calculation during recalculation
- Ensure both rating systems stay in sync during recalculation process

## Test plan
- [x] Verify ReScript compilation succeeds
- [x] Verify Next.js build completes successfully  
- [x] Confirm compiled JavaScript includes both OpenSkill and Elo calculations
- [ ] Test admin recalculate button updates both rating systems correctly
- [ ] Verify foosball games update both elo and OpenSkill fields after recalculation

🤖 Generated with [Claude Code](https://claude.ai/code)