### PR TITLE
Update leaderboard score and position display

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -25,6 +25,12 @@
   transition: transform 0.6s ease-in-out;
 }
 
+@media (min-width: 1200px) {
+  .modal {
+    width: min(calc(800px + var(--overflow)), calc(100vw + var(--overflow)));
+  }
+}
+
 @supports (animation-timing-function: linear(0, 1)) {
   .modal {
     transition: transform 0.6s

--- a/src/components/LeaderboardModal.bs.mjs
+++ b/src/components/LeaderboardModal.bs.mjs
@@ -151,7 +151,7 @@ function LeaderboardModal(props) {
                 }),
             JsxRuntime.jsx("th", {
                   children: JsxRuntime.jsx("button", {
-                        children: "Ordinal " + (
+                        children: "Ord. " + (
                           ascOrder ? "↑" : "↓"
                         ),
                         "aria-label": "Toggle sort order",

--- a/src/components/LeaderboardModal.bs.mjs
+++ b/src/components/LeaderboardModal.bs.mjs
@@ -3,9 +3,12 @@
 import * as Elo from "../helpers/Elo.bs.mjs";
 import * as React from "react";
 import * as Button from "./Button.bs.mjs";
+import * as Js_dict from "rescript/lib/es6/js_dict.js";
 import * as Players from "../helpers/Players.bs.mjs";
 import * as DartsIcon from "./DartsIcon.bs.mjs";
 import * as SoccerIcon from "./SoccerIcon.bs.mjs";
+import * as PervasivesU from "rescript/lib/es6/pervasivesU.js";
+import * as Core__Option from "@rescript/core/src/Core__Option.bs.mjs";
 import * as OpenSkillRating from "../helpers/OpenSkillRating.bs.mjs";
 import * as JsxRuntime from "react/jsx-runtime";
 
@@ -19,14 +22,99 @@ function LeaderboardModal(props) {
   var setOrder = match[1];
   var ascOrder = match[0];
   var players = Players.useAllPlayers(gameMode === "Darts" ? "dartsElo" : "rating", ascOrder);
-  var position = {
-    contents: 0
+  var visiblePlayers = React.useMemo((function () {
+          return players.filter(function (player) {
+                      var match;
+                      match = gameMode === "Foosball" ? [
+                          player.ordinal,
+                          player.games
+                        ] : [
+                          player.dartsElo,
+                          player.dartsGames
+                        ];
+                      var match$1 = player.hidden;
+                      var isHidden = match$1 !== undefined && match$1 ? false : true;
+                      var isLowGameCount = match[1] > 5;
+                      if (isHidden) {
+                        return isLowGameCount;
+                      } else {
+                        return false;
+                      }
+                    });
+        }), [
+        players,
+        gameMode
+      ]);
+  var getCurrentCompareValue = function (player) {
+    if (gameMode === "Foosball") {
+      return OpenSkillRating.toDisplayOrdinal(player.ordinal);
+    } else {
+      return Elo.roundScore(player.dartsElo);
+    }
   };
-  var previousScore = {
-    contents: 0
+  var getPreviousCompareValue = function (player) {
+    if (gameMode === "Foosball") {
+      return OpenSkillRating.toDisplayOrdinal(player.ordinal - player.lastOpenSkillChange);
+    } else {
+      return Elo.roundScore(player.dartsElo - player.dartsLastEloChange);
+    }
   };
-  var skipped = {
-    contents: 0
+  var computePositions = function (arr, getValue) {
+    var posByKey = {};
+    var position = {
+      contents: 0
+    };
+    var skipped = {
+      contents: 0
+    };
+    var previousValue = {
+      contents: undefined
+    };
+    arr.forEach(function (player) {
+          var value = getValue(player);
+          var prev = previousValue.contents;
+          if (prev !== undefined) {
+            if (prev === value) {
+              skipped.contents = skipped.contents + 1 | 0;
+            } else if (skipped.contents > 0) {
+              position.contents = (position.contents + skipped.contents | 0) + 1 | 0;
+              skipped.contents = 0;
+            } else {
+              position.contents = position.contents + 1 | 0;
+            }
+          } else {
+            position.contents = position.contents + 1 | 0;
+          }
+          previousValue.contents = value;
+          posByKey[player.key] = position.contents;
+        });
+    return posByKey;
+  };
+  var currentPositions = React.useMemo((function () {
+          return computePositions(visiblePlayers, getCurrentCompareValue);
+        }), [
+        visiblePlayers,
+        gameMode
+      ]);
+  var previousPositions = React.useMemo((function () {
+          var sortedPrev = visiblePlayers.toSorted(function (a, b) {
+                var match = ascOrder ? [
+                    a,
+                    b
+                  ] : [
+                    b,
+                    a
+                  ];
+                return getPreviousCompareValue(match[0]) - getPreviousCompareValue(match[1]) | 0;
+              });
+          return computePositions(sortedPrev, getPreviousCompareValue);
+        }), [
+        visiblePlayers,
+        ascOrder,
+        gameMode
+      ]);
+  var round2 = function (v) {
+    return Math.round(v * 100.0) / 100.0;
   };
   var tmp;
   tmp = setGameMode !== undefined ? (
@@ -110,24 +198,7 @@ function LeaderboardModal(props) {
                                   })
                             }),
                         JsxRuntime.jsx("tbody", {
-                              children: players.filter(function (player) {
-                                      var match = player.hidden;
-                                      var isHidden = match !== undefined && match ? false : true;
-                                      var match$1;
-                                      match$1 = gameMode === "Foosball" ? [
-                                          player.ordinal,
-                                          player.games
-                                        ] : [
-                                          player.dartsElo,
-                                          player.dartsGames
-                                        ];
-                                      var isLowGameCount = match$1[1] > 5;
-                                      if (isHidden) {
-                                        return isLowGameCount;
-                                      } else {
-                                        return false;
-                                      }
-                                    }).map(function (player) {
+                              children: visiblePlayers.map(function (player) {
                                     var match;
                                     match = gameMode === "Foosball" ? [
                                         player.ordinal,
@@ -144,61 +215,39 @@ function LeaderboardModal(props) {
                                       ];
                                     var games = match[4];
                                     var wins = match[3];
-                                    var lastChange = match[1];
-                                    var displayScore = match[0];
-                                    var roundedScore;
-                                    roundedScore = gameMode === "Foosball" ? OpenSkillRating.toDisplayOrdinal(displayScore) : Elo.roundScore(displayScore);
-                                    var match$1 = previousScore.contents;
-                                    var match$2 = skipped.contents;
-                                    if (roundedScore === match$1) {
-                                      skipped.contents = skipped.contents + 1 | 0;
-                                    } else if (match$2 > 0) {
-                                      position.contents = (position.contents + skipped.contents | 0) + 1 | 0;
-                                      skipped.contents = 0;
-                                    } else {
-                                      position.contents = position.contents + 1 | 0;
-                                    }
-                                    previousScore.contents = roundedScore;
+                                    var currentPos = Core__Option.getOr(Js_dict.get(currentPositions, player.key), 0);
+                                    var previousPos = Core__Option.getOr(Js_dict.get(previousPositions, player.key), currentPos);
+                                    var delta = previousPos - currentPos | 0;
+                                    var deltaAbs = PervasivesU.abs(delta);
+                                    var deltaColor = delta === 0 ? "text-gray-400" : (
+                                        delta > 0 ? "text-green-400" : "text-red-400"
+                                      );
                                     var tmp;
                                     tmp = gameMode === "Foosball" ? JsxRuntime.jsxs("span", {
                                             children: [
                                               JsxRuntime.jsx("span", {
-                                                    children: roundedScore,
-                                                    className: "group-hover:hidden"
-                                                  }),
-                                              JsxRuntime.jsx("span", {
-                                                    children: Elo.roundScore(player.elo),
-                                                    className: "hidden group-hover:inline"
-                                                  }),
-                                              " ",
-                                              JsxRuntime.jsx("small", {
-                                                    children: OpenSkillRating.toDisplayDelta(lastChange),
-                                                    className: (
-                                                      lastChange > 0.0 ? "text-green-400" : "text-red-400"
-                                                    ) + " group-hover:hidden"
+                                                    children: round2(player.mu).toString() + " / " + round2(player.sigma).toString() + " / " + round2(player.ordinal).toString()
                                                   }),
                                               JsxRuntime.jsx("small", {
-                                                    children: Elo.roundScore(player.lastEloChange),
-                                                    className: (
-                                                      player.lastEloChange > 0.0 ? "text-green-400" : "text-red-400"
-                                                    ) + " hidden group-hover:inline"
+                                                    children: delta === 0 ? "-" : deltaAbs,
+                                                    className: deltaColor
                                                   })
                                             ],
-                                            className: "group inline-flex items-baseline gap-1"
+                                            className: "inline-flex items-baseline gap-2"
                                           }) : JsxRuntime.jsxs(JsxRuntime.Fragment, {
                                             children: [
-                                              roundedScore,
+                                              Elo.roundScore(player.dartsElo),
                                               " ",
                                               JsxRuntime.jsx("small", {
-                                                    children: Elo.roundScore(lastChange),
-                                                    className: lastChange > 0.0 ? "text-green-400" : "text-red-400"
+                                                    children: delta === 0 ? "-" : deltaAbs,
+                                                    className: deltaColor
                                                   })
                                             ]
                                           });
                                     return JsxRuntime.jsxs("tr", {
                                                 children: [
                                                   JsxRuntime.jsx("td", {
-                                                        children: position.contents.toString(),
+                                                        children: currentPos.toString(),
                                                         className: "font-semibold"
                                                       }),
                                                   JsxRuntime.jsx("td", {

--- a/src/components/LeaderboardModal.bs.mjs
+++ b/src/components/LeaderboardModal.bs.mjs
@@ -33,10 +33,10 @@ function LeaderboardModal(props) {
                           player.dartsGames
                         ];
                       var match$1 = player.hidden;
-                      var isHidden = match$1 !== undefined && match$1 ? false : true;
-                      var isLowGameCount = match[1] > 5;
-                      if (isHidden) {
-                        return isLowGameCount;
+                      var isVisible = match$1 !== undefined && match$1 ? false : true;
+                      var hasEnoughGames = match[1] > 5;
+                      if (isVisible) {
+                        return hasEnoughGames;
                       } else {
                         return false;
                       }
@@ -120,6 +120,7 @@ function LeaderboardModal(props) {
   tmp = setGameMode !== undefined ? (
       gameMode === "Foosball" ? JsxRuntime.jsx("button", {
               children: JsxRuntime.jsx(SoccerIcon.make, {}),
+              "aria-label": "Switch to Darts leaderboard",
               className: "text-white w-[44px] aspect-square text-[26px] flex justify-center items-center rounded-full bg-black/0 transition-all ease-in-out duration-200 shadow-none hover:bg-black/20 hover:shadow-icon-button hover:ring-8 ring-black/20 active:bg-black/20 active:shadow-icon-button active:ring-8",
               onClick: (function (param) {
                   setGameMode(function (param) {
@@ -128,6 +129,7 @@ function LeaderboardModal(props) {
                 })
             }) : JsxRuntime.jsx("button", {
               children: JsxRuntime.jsx(DartsIcon.make, {}),
+              "aria-label": "Switch to Foosball leaderboard",
               className: "text-white w-[44px] aspect-square text-[26px] flex justify-center items-center rounded-full bg-black/0 transition-all ease-in-out duration-200 shadow-none hover:bg-black/20 hover:shadow-icon-button hover:ring-8 ring-black/20 active:bg-black/20 active:shadow-icon-button active:ring-8",
               onClick: (function (param) {
                   setGameMode(function (param) {
@@ -174,6 +176,7 @@ function LeaderboardModal(props) {
                                                   children: "Score " + (
                                                     ascOrder ? "↑" : "↓"
                                                   ),
+                                                  "aria-label": "Toggle sort order",
                                                   onClick: (function (param) {
                                                       setOrder(function (order) {
                                                             return !order;
@@ -277,7 +280,7 @@ function LeaderboardModal(props) {
                                                       }),
                                                   JsxRuntime.jsxs("td", {
                                                         children: [
-                                                          Math.round(wins / games * 100),
+                                                          Math.round(games > 0 ? wins / games * 100 : 0.0),
                                                           "%"
                                                         ]
                                                       })

--- a/src/components/LeaderboardModal.bs.mjs
+++ b/src/components/LeaderboardModal.bs.mjs
@@ -227,6 +227,14 @@ function LeaderboardModal(props) {
                                       JsxRuntime.jsx("th", {
                                             children: "Last 5",
                                             className: "text-lg text-left"
+                                          }),
+                                      JsxRuntime.jsx("th", {
+                                            children: "G/W",
+                                            className: "text-lg text-left hidden min-[1200px]:table-cell"
+                                          }),
+                                      JsxRuntime.jsx("th", {
+                                            children: "Win%",
+                                            className: "text-lg text-left hidden min-[1200px]:table-cell"
                                           })
                                     ]
                                   })
@@ -247,6 +255,8 @@ function LeaderboardModal(props) {
                                         player.dartsWins,
                                         player.dartsGames
                                       ];
+                                    var games = match[4];
+                                    var wins = match[3];
                                     var currentPos = Core__Option.getOr(Js_dict.get(currentPositions, player.key), 0);
                                     var previousPos = Core__Option.getOr(Js_dict.get(previousPositions, player.key), currentPos);
                                     var delta = previousPos - currentPos | 0;
@@ -307,6 +317,21 @@ function LeaderboardModal(props) {
                                                                   }),
                                                               className: "inline-flex gap-1 w-9"
                                                             })
+                                                      }),
+                                                  JsxRuntime.jsxs("td", {
+                                                        children: [
+                                                          games,
+                                                          ":",
+                                                          wins
+                                                        ],
+                                                        className: "hidden min-[1200px]:table-cell"
+                                                      }),
+                                                  JsxRuntime.jsxs("td", {
+                                                        children: [
+                                                          Math.round(games > 0 ? wins / games * 100 : 0.0),
+                                                          "%"
+                                                        ],
+                                                        className: "hidden min-[1200px]:table-cell"
                                                       })
                                                 ]
                                               }, player.key);

--- a/src/components/LeaderboardModal.bs.mjs
+++ b/src/components/LeaderboardModal.bs.mjs
@@ -138,6 +138,58 @@ function LeaderboardModal(props) {
                 })
             })
     ) : null;
+  var tmp$1;
+  tmp$1 = gameMode === "Foosball" ? JsxRuntime.jsxs(JsxRuntime.Fragment, {
+          children: [
+            JsxRuntime.jsx("th", {
+                  children: "μ",
+                  className: "text-lg text-left"
+                }),
+            JsxRuntime.jsx("th", {
+                  children: "σ",
+                  className: "text-lg text-left"
+                }),
+            JsxRuntime.jsx("th", {
+                  children: JsxRuntime.jsx("button", {
+                        children: "Ordinal " + (
+                          ascOrder ? "↑" : "↓"
+                        ),
+                        "aria-label": "Toggle sort order",
+                        onClick: (function (param) {
+                            setOrder(function (order) {
+                                  return !order;
+                                });
+                          })
+                      }),
+                  className: "text-lg text-left"
+                }),
+            JsxRuntime.jsx("th", {
+                  children: "Δ",
+                  className: "text-lg text-left"
+                })
+          ]
+        }) : JsxRuntime.jsxs(JsxRuntime.Fragment, {
+          children: [
+            JsxRuntime.jsx("th", {
+                  children: JsxRuntime.jsx("button", {
+                        children: "Elo " + (
+                          ascOrder ? "↑" : "↓"
+                        ),
+                        "aria-label": "Toggle sort order",
+                        onClick: (function (param) {
+                            setOrder(function (order) {
+                                  return !order;
+                                });
+                          })
+                      }),
+                  className: "text-lg text-left"
+                }),
+            JsxRuntime.jsx("th", {
+                  children: "Δ",
+                  className: "text-lg text-left"
+                })
+          ]
+        });
   return JsxRuntime.jsxs("div", {
               children: [
                 JsxRuntime.jsxs("header", {
@@ -171,30 +223,9 @@ function LeaderboardModal(props) {
                                             children: "Speler",
                                             className: "text-lg text-left"
                                           }),
-                                      JsxRuntime.jsx("th", {
-                                            children: JsxRuntime.jsx("button", {
-                                                  children: "Score " + (
-                                                    ascOrder ? "↑" : "↓"
-                                                  ),
-                                                  "aria-label": "Toggle sort order",
-                                                  onClick: (function (param) {
-                                                      setOrder(function (order) {
-                                                            return !order;
-                                                          });
-                                                    })
-                                                }),
-                                            className: "text-lg text-left"
-                                          }),
+                                      tmp$1,
                                       JsxRuntime.jsx("th", {
                                             children: "Last 5",
-                                            className: "text-lg text-left"
-                                          }),
-                                      JsxRuntime.jsx("th", {
-                                            children: "G/W",
-                                            className: "text-lg text-left"
-                                          }),
-                                      JsxRuntime.jsx("th", {
-                                            children: "Win%",
                                             className: "text-lg text-left"
                                           })
                                     ]
@@ -216,8 +247,6 @@ function LeaderboardModal(props) {
                                         player.dartsWins,
                                         player.dartsGames
                                       ];
-                                    var games = match[4];
-                                    var wins = match[3];
                                     var currentPos = Core__Option.getOr(Js_dict.get(currentPositions, player.key), 0);
                                     var previousPos = Core__Option.getOr(Js_dict.get(previousPositions, player.key), currentPos);
                                     var delta = previousPos - currentPos | 0;
@@ -226,24 +255,34 @@ function LeaderboardModal(props) {
                                         delta > 0 ? "text-green-400" : "text-red-400"
                                       );
                                     var tmp;
-                                    tmp = gameMode === "Foosball" ? JsxRuntime.jsxs("span", {
+                                    tmp = gameMode === "Foosball" ? JsxRuntime.jsxs(JsxRuntime.Fragment, {
                                             children: [
-                                              JsxRuntime.jsx("span", {
-                                                    children: round2(player.mu).toString() + " / " + round2(player.sigma).toString() + " / " + round2(player.ordinal).toString()
+                                              JsxRuntime.jsx("td", {
+                                                    children: round2(player.mu)
                                                   }),
-                                              JsxRuntime.jsx("small", {
-                                                    children: delta === 0 ? "-" : deltaAbs,
-                                                    className: deltaColor
+                                              JsxRuntime.jsx("td", {
+                                                    children: round2(player.sigma)
+                                                  }),
+                                              JsxRuntime.jsx("td", {
+                                                    children: round2(player.ordinal)
+                                                  }),
+                                              JsxRuntime.jsx("td", {
+                                                    children: JsxRuntime.jsx("small", {
+                                                          children: delta === 0 ? "-" : deltaAbs,
+                                                          className: deltaColor
+                                                        })
                                                   })
-                                            ],
-                                            className: "inline-flex items-baseline gap-2"
+                                            ]
                                           }) : JsxRuntime.jsxs(JsxRuntime.Fragment, {
                                             children: [
-                                              Elo.roundScore(player.dartsElo),
-                                              " ",
-                                              JsxRuntime.jsx("small", {
-                                                    children: delta === 0 ? "-" : deltaAbs,
-                                                    className: deltaColor
+                                              JsxRuntime.jsx("td", {
+                                                    children: Elo.roundScore(player.dartsElo)
+                                                  }),
+                                              JsxRuntime.jsx("td", {
+                                                    children: JsxRuntime.jsx("small", {
+                                                          children: delta === 0 ? "-" : deltaAbs,
+                                                          className: deltaColor
+                                                        })
                                                   })
                                             ]
                                           });
@@ -256,9 +295,7 @@ function LeaderboardModal(props) {
                                                   JsxRuntime.jsx("td", {
                                                         children: player.name
                                                       }),
-                                                  JsxRuntime.jsx("td", {
-                                                        children: tmp
-                                                      }),
+                                                  tmp,
                                                   JsxRuntime.jsx("td", {
                                                         children: JsxRuntime.jsx("div", {
                                                               children: match[2].map(function (win, i) {
@@ -270,19 +307,6 @@ function LeaderboardModal(props) {
                                                                   }),
                                                               className: "inline-flex gap-1 w-9"
                                                             })
-                                                      }),
-                                                  JsxRuntime.jsxs("td", {
-                                                        children: [
-                                                          games,
-                                                          ":",
-                                                          wins
-                                                        ]
-                                                      }),
-                                                  JsxRuntime.jsxs("td", {
-                                                        children: [
-                                                          Math.round(games > 0 ? wins / games * 100 : 0.0),
-                                                          "%"
-                                                        ]
                                                       })
                                                 ]
                                               }, player.key);

--- a/src/components/LeaderboardModal.res
+++ b/src/components/LeaderboardModal.res
@@ -118,7 +118,7 @@ let make = (~show, ~setShow, ~gameMode, ~setGameMode) => {
               <th className="text-lg text-left"> {React.string("σ")} </th>
               <th className="text-lg text-left">
                 <button ariaLabel="Toggle sort order" onClick={_ => setOrder(order => !order)}>
-                  {React.string("Ordinal " ++ (ascOrder ? "↑" : "↓"))}
+                  {React.string("Ord. " ++ (ascOrder ? "↑" : "↓"))}
                 </button>
               </th>
               <th className="text-lg text-left"> {React.string("Δ")} </th>

--- a/src/components/LeaderboardModal.res
+++ b/src/components/LeaderboardModal.res
@@ -134,12 +134,14 @@ let make = (~show, ~setShow, ~gameMode, ~setGameMode) => {
             </>
           }}
           <th className="text-lg text-left"> {React.string("Last 5")} </th>
+          <th className="text-lg text-left hidden min-[1200px]:table-cell"> {React.string("G/W")} </th>
+          <th className="text-lg text-left hidden min-[1200px]:table-cell"> {React.string("Win%")} </th>
         </tr>
       </thead>
       <tbody>
         {visiblePlayers
         ->Array.map(player => {
-          let (_, _lastChange, lastGames, _wins, _games) = switch gameMode {
+          let (_, _lastChange, lastGames, wins, games) = switch gameMode {
           | Games.Darts => (
               player.dartsElo,
               player.dartsLastEloChange,
@@ -203,6 +205,15 @@ let make = (~show, ~setShow, ~gameMode, ~setGameMode) => {
                 )
                 ->React.array}
               </div>
+            </td>
+            <td className="hidden min-[1200px]:table-cell">
+              {React.int(games)}
+              {React.string(":")}
+              {React.int(wins)}
+            </td>
+            <td className="hidden min-[1200px]:table-cell">
+              {React.float((games > 0 ? (Float.fromInt(wins) /. Float.fromInt(games) *. 100.) : 0.0)->Math.round)}
+              {React.string("%")}
             </td>
           </tr>
         })

--- a/src/components/LeaderboardModal.res
+++ b/src/components/LeaderboardModal.res
@@ -111,20 +111,35 @@ let make = (~show, ~setShow, ~gameMode, ~setGameMode) => {
             {React.string("#")}
           </th>
           <th className="text-lg text-left"> {React.string("Speler")} </th>
-          <th className="text-lg text-left">
-            <button ariaLabel="Toggle sort order" onClick={_ => setOrder(order => !order)}>
-              {React.string("Score " ++ (ascOrder ? "↑" : "↓"))}
-            </button>
-          </th>
+          {switch gameMode {
+          | Games.Foosball =>
+            <>
+              <th className="text-lg text-left"> {React.string("μ")} </th>
+              <th className="text-lg text-left"> {React.string("σ")} </th>
+              <th className="text-lg text-left">
+                <button ariaLabel="Toggle sort order" onClick={_ => setOrder(order => !order)}>
+                  {React.string("Ordinal " ++ (ascOrder ? "↑" : "↓"))}
+                </button>
+              </th>
+              <th className="text-lg text-left"> {React.string("Δ")} </th>
+            </>
+          | Games.Darts =>
+            <>
+              <th className="text-lg text-left">
+                <button ariaLabel="Toggle sort order" onClick={_ => setOrder(order => !order)}>
+                  {React.string("Elo " ++ (ascOrder ? "↑" : "↓"))}
+                </button>
+              </th>
+              <th className="text-lg text-left"> {React.string("Δ")} </th>
+            </>
+          }}
           <th className="text-lg text-left"> {React.string("Last 5")} </th>
-          <th className="text-lg text-left"> {React.string("G/W")} </th>
-          <th className="text-lg text-left"> {React.string("Win%")} </th>
         </tr>
       </thead>
       <tbody>
         {visiblePlayers
         ->Array.map(player => {
-          let (_, lastChange, lastGames, wins, games) = switch gameMode {
+          let (_, _lastChange, lastGames, _wins, _games) = switch gameMode {
           | Games.Darts => (
               player.dartsElo,
               player.dartsLastEloChange,
@@ -153,27 +168,28 @@ let make = (~show, ~setShow, ~gameMode, ~setGameMode) => {
               {React.string(`${currentPos->Int.toString}`)}
             </td>
             <td> {React.string(player.name)} </td>
-            <td>
-              {switch gameMode {
-              | Games.Darts =>
-                <>
-                  {React.int(Elo.roundScore(player.dartsElo))}
-                  {React.string(" ")}
+            {switch gameMode {
+            | Games.Darts =>
+              <>
+                <td> {React.int(Elo.roundScore(player.dartsElo))} </td>
+                <td>
                   <small className={deltaColor}>
                     {delta == 0 ? React.string("-") : React.int(deltaAbs)}
                   </small>
-                </>
-              | Games.Foosball =>
-                <span className="inline-flex items-baseline gap-2">
-                  <span>
-                    {React.string(`${round2(player.mu)->Float.toString} / ${round2(player.sigma)->Float.toString} / ${round2(player.ordinal)->Float.toString}`)}
-                  </span>
+                </td>
+              </>
+            | Games.Foosball =>
+              <>
+                <td> {React.float(round2(player.mu))} </td>
+                <td> {React.float(round2(player.sigma))} </td>
+                <td> {React.float(round2(player.ordinal))} </td>
+                <td>
                   <small className={deltaColor}>
                     {delta == 0 ? React.string("-") : React.int(deltaAbs)}
                   </small>
-                </span>
-              }}
-            </td>
+                </td>
+              </>
+            }}
             <td>
               <div className="inline-flex gap-1 w-9">
                 {lastGames
@@ -187,15 +203,6 @@ let make = (~show, ~setShow, ~gameMode, ~setGameMode) => {
                 )
                 ->React.array}
               </div>
-            </td>
-            <td>
-              {React.int(games)}
-              {React.string(":")}
-              {React.int(wins)}
-            </td>
-            <td>
-              {React.float((games > 0 ? (Float.fromInt(wins) /. Float.fromInt(games) *. 100.) : 0.0)->Math.round)}
-              {React.string("%")}
             </td>
           </tr>
         })

--- a/src/components/LeaderboardModal.res
+++ b/src/components/LeaderboardModal.res
@@ -15,14 +15,14 @@ let make = (~show, ~setShow, ~gameMode, ~setGameMode) => {
       | _ => (player.ordinal, player.games)
       }
 
-      let isHidden = switch player.hidden {
+      let isVisible = switch player.hidden {
       | Some(true) => false
       | Some(false) => true
       | None => true
       }
 
-      let isLowGameCount = games > 5
-      isHidden && isLowGameCount
+      let hasEnoughGames = games > 5
+      isVisible && hasEnoughGames
     })
   , (players, gameMode))
 
@@ -88,12 +88,14 @@ let make = (~show, ~setShow, ~gameMode, ~setGameMode) => {
         switch gameMode {
         | Games.Foosball =>
           <button
+            ariaLabel="Switch to Darts leaderboard"
             className="text-white w-[44px] aspect-square text-[26px] flex justify-center items-center rounded-full bg-black/0 transition-all ease-in-out duration-200 shadow-none hover:bg-black/20 hover:shadow-icon-button hover:ring-8 ring-black/20 active:bg-black/20 active:shadow-icon-button active:ring-8"
             onClick={_ => setGameMode(_ => Games.Darts)}>
             <SoccerIcon />
           </button>
         | Games.Darts =>
           <button
+            ariaLabel="Switch to Foosball leaderboard"
             className="text-white w-[44px] aspect-square text-[26px] flex justify-center items-center rounded-full bg-black/0 transition-all ease-in-out duration-200 shadow-none hover:bg-black/20 hover:shadow-icon-button hover:ring-8 ring-black/20 active:bg-black/20 active:shadow-icon-button active:ring-8"
             onClick={_ => setGameMode(_ => Games.Foosball)}>
             <DartsIcon />
@@ -110,7 +112,7 @@ let make = (~show, ~setShow, ~gameMode, ~setGameMode) => {
           </th>
           <th className="text-lg text-left"> {React.string("Speler")} </th>
           <th className="text-lg text-left">
-            <button onClick={_ => setOrder(order => !order)}>
+            <button ariaLabel="Toggle sort order" onClick={_ => setOrder(order => !order)}>
               {React.string("Score " ++ (ascOrder ? "↑" : "↓"))}
             </button>
           </th>
@@ -192,7 +194,7 @@ let make = (~show, ~setShow, ~gameMode, ~setGameMode) => {
               {React.int(wins)}
             </td>
             <td>
-              {React.float((Float.fromInt(wins) /. Float.fromInt(games) *. 100.)->Math.round)}
+              {React.float((games > 0 ? (Float.fromInt(wins) /. Float.fromInt(games) *. 100.) : 0.0)->Math.round)}
               {React.string("%")}
             </td>
           </tr>


### PR DESCRIPTION
Update leaderboard to display mu/sigma/ordinal for Foosball scores and show position change instead of score change.

---
<a href="https://cursor.com/background-agent?bcId=bc-d973fb16-e91a-4239-bc9d-2859b2827b87">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d973fb16-e91a-4239-bc9d-2859b2827b87">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

