### PR TITLE
Update leaderboard score display and tooltip

### DIFF
--- a/src/components/LeaderboardModal.bs.mjs
+++ b/src/components/LeaderboardModal.bs.mjs
@@ -142,16 +142,8 @@ function LeaderboardModal(props) {
   tmp$1 = gameMode === "Foosball" ? JsxRuntime.jsxs(JsxRuntime.Fragment, {
           children: [
             JsxRuntime.jsx("th", {
-                  children: "μ",
-                  className: "text-lg text-left"
-                }),
-            JsxRuntime.jsx("th", {
-                  children: "σ",
-                  className: "text-lg text-left"
-                }),
-            JsxRuntime.jsx("th", {
                   children: JsxRuntime.jsx("button", {
-                        children: "Ord. " + (
+                        children: "Score " + (
                           ascOrder ? "↑" : "↓"
                         ),
                         "aria-label": "Toggle sort order",
@@ -230,11 +222,11 @@ function LeaderboardModal(props) {
                                           }),
                                       JsxRuntime.jsx("th", {
                                             children: "G/W",
-                                            className: "text-lg text-left hidden min-[1200px]:table-cell"
+                                            className: "text-lg text-left"
                                           }),
                                       JsxRuntime.jsx("th", {
                                             children: "Win%",
-                                            className: "text-lg text-left hidden min-[1200px]:table-cell"
+                                            className: "text-lg text-left"
                                           })
                                     ]
                                   })
@@ -268,13 +260,8 @@ function LeaderboardModal(props) {
                                     tmp = gameMode === "Foosball" ? JsxRuntime.jsxs(JsxRuntime.Fragment, {
                                             children: [
                                               JsxRuntime.jsx("td", {
-                                                    children: round2(player.mu)
-                                                  }),
-                                              JsxRuntime.jsx("td", {
-                                                    children: round2(player.sigma)
-                                                  }),
-                                              JsxRuntime.jsx("td", {
-                                                    children: round2(player.ordinal)
+                                                    children: OpenSkillRating.toDisplayOrdinal(player.ordinal),
+                                                    title: "μ=" + round2(player.mu).toString() + " σ=" + round2(player.sigma).toString() + " ELO=" + round2(player.elo).toString()
                                                   }),
                                               JsxRuntime.jsx("td", {
                                                     children: JsxRuntime.jsx("small", {
@@ -323,15 +310,13 @@ function LeaderboardModal(props) {
                                                           games,
                                                           ":",
                                                           wins
-                                                        ],
-                                                        className: "hidden min-[1200px]:table-cell"
+                                                        ]
                                                       }),
                                                   JsxRuntime.jsxs("td", {
                                                         children: [
-                                                          Math.round(games > 0 ? wins / games * 100 : 0.0),
+                                                          Math.round(games > 0 ? wins / games * 100 : 0.0) | 0,
                                                           "%"
-                                                        ],
-                                                        className: "hidden min-[1200px]:table-cell"
+                                                        ]
                                                       })
                                                 ]
                                               }, player.key);

--- a/src/components/LeaderboardModal.bs.mjs
+++ b/src/components/LeaderboardModal.bs.mjs
@@ -260,7 +260,7 @@ function LeaderboardModal(props) {
                                     tmp = gameMode === "Foosball" ? JsxRuntime.jsxs(JsxRuntime.Fragment, {
                                             children: [
                                               JsxRuntime.jsx("td", {
-                                                    children: OpenSkillRating.toDisplayOrdinal(player.ordinal),
+                                                    children: Math.round(player.ordinal) | 0,
                                                     title: "μ=" + round2(player.mu).toString() + " σ=" + round2(player.sigma).toString() + " ELO=" + round2(player.elo).toString()
                                                   }),
                                               JsxRuntime.jsx("td", {

--- a/src/components/LeaderboardModal.res
+++ b/src/components/LeaderboardModal.res
@@ -180,9 +180,9 @@ let make = (~show, ~setShow, ~gameMode, ~setGameMode) => {
               </>
             | Games.Foosball =>
               <>
-                                 <td title={"μ=" ++ round2(player.mu)->Js.Float.toString ++ " σ=" ++ round2(player.sigma)->Js.Float.toString ++ " ELO=" ++ round2(player.elo)->Js.Float.toString}>
-                  {React.int(OpenSkillRating.toDisplayOrdinal(player.ordinal))}
-                </td>
+                                                  <td title={"μ=" ++ round2(player.mu)->Js.Float.toString ++ " σ=" ++ round2(player.sigma)->Js.Float.toString ++ " ELO=" ++ round2(player.elo)->Js.Float.toString}>
+                   {React.int(Js.Math.round(player.ordinal)->Float.toInt)}
+                 </td>
                 <td>
                   <small className={deltaColor}>
                     {delta == 0 ? React.string("-") : React.int(deltaAbs)}

--- a/src/components/LeaderboardModal.res
+++ b/src/components/LeaderboardModal.res
@@ -132,8 +132,8 @@ let make = (~show, ~setShow, ~gameMode, ~setGameMode) => {
             </>
           }}
           <th className="text-lg text-left"> {React.string("Last 5")} </th>
-          <th className="text-lg text-left hidden min-[1200px]:table-cell"> {React.string("G/W")} </th>
-          <th className="text-lg text-left hidden min-[1200px]:table-cell"> {React.string("Win%")} </th>
+                     <th className="text-lg text-left"> {React.string("G/W")} </th>
+          <th className="text-lg text-left"> {React.string("Win%") } </th>
         </tr>
       </thead>
       <tbody>
@@ -180,8 +180,8 @@ let make = (~show, ~setShow, ~gameMode, ~setGameMode) => {
               </>
             | Games.Foosball =>
               <>
-                <td title={"μ=" ++ round2(player.mu)->Js.Float.toString ++ " σ=" ++ round2(player.sigma)->Js.Float.toString ++ " ELO=" ++ round2(player.elo)->Js.Float.toString}>
-                  {React.float(round2(player.ordinal))}
+                                 <td title={"μ=" ++ round2(player.mu)->Js.Float.toString ++ " σ=" ++ round2(player.sigma)->Js.Float.toString ++ " ELO=" ++ round2(player.elo)->Js.Float.toString}>
+                  {React.int(OpenSkillRating.toDisplayOrdinal(player.ordinal))}
                 </td>
                 <td>
                   <small className={deltaColor}>
@@ -204,14 +204,14 @@ let make = (~show, ~setShow, ~gameMode, ~setGameMode) => {
                 ->React.array}
               </div>
             </td>
-            <td className="hidden min-[1200px]:table-cell">
+            <td>
               {React.int(games)}
               {React.string(":")}
               {React.int(wins)}
             </td>
-            <td className="hidden min-[1200px]:table-cell">
-              {React.float((games > 0 ? (Float.fromInt(wins) /. Float.fromInt(games) *. 100.) : 0.0)->Math.round)}
-              {React.string("%")}
+            <td>
+              {React.int((games > 0 ? (Float.fromInt(wins) /. Float.fromInt(games) *. 100.) : 0.0)->Js.Math.round->Float.toInt)}
+              {React.string("%") }
             </td>
           </tr>
         })

--- a/src/components/LeaderboardModal.res
+++ b/src/components/LeaderboardModal.res
@@ -114,11 +114,9 @@ let make = (~show, ~setShow, ~gameMode, ~setGameMode) => {
           {switch gameMode {
           | Games.Foosball =>
             <>
-              <th className="text-lg text-left"> {React.string("μ")} </th>
-              <th className="text-lg text-left"> {React.string("σ")} </th>
               <th className="text-lg text-left">
                 <button ariaLabel="Toggle sort order" onClick={_ => setOrder(order => !order)}>
-                  {React.string("Ord. " ++ (ascOrder ? "↑" : "↓"))}
+                  {React.string("Score " ++ (ascOrder ? "↑" : "↓"))}
                 </button>
               </th>
               <th className="text-lg text-left"> {React.string("Δ")} </th>
@@ -182,9 +180,9 @@ let make = (~show, ~setShow, ~gameMode, ~setGameMode) => {
               </>
             | Games.Foosball =>
               <>
-                <td> {React.float(round2(player.mu))} </td>
-                <td> {React.float(round2(player.sigma))} </td>
-                <td> {React.float(round2(player.ordinal))} </td>
+                <td title={"μ=" ++ round2(player.mu)->Js.Float.toString ++ " σ=" ++ round2(player.sigma)->Js.Float.toString ++ " ELO=" ++ round2(player.elo)->Js.Float.toString}>
+                  {React.float(round2(player.ordinal))}
+                </td>
                 <td>
                   <small className={deltaColor}>
                     {delta == 0 ? React.string("-") : React.int(deltaAbs)}


### PR DESCRIPTION
Streamlines Foosball leaderboard display by showing only rounded score with hover details and making G/W and Win% columns always visible.

---
<a href="https://cursor.com/background-agent?bcId=bc-b500f593-bf5a-486a-9c6a-37d9fec9ce8f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b500f593-bf5a-486a-9c6a-37d9fec9ce8f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

