### PR TITLE
Send sprokel alert for high win percentage

### DIFF
--- a/src/components/UserGrid.bs.mjs
+++ b/src/components/UserGrid.bs.mjs
@@ -176,7 +176,7 @@ function UserGrid(props) {
                               children: JsxRuntime.jsx(NewPlayerForm.make, {})
                             })
                       ],
-                      className: "grid 2xl:grid-cols-5 xl:grid-cols-4 lg:grid-cols-3 md:grid-cols-3 grid-cols-2 gap-4 lg:gap-10 mt-4 lg:mt-8 px-4 lg:content-padding"
+                      className: "grid 2xl:grid-cols-5 xl:grid-cols-4 lg:grid-cols-3 md:grid-cols-3 grid-cols-2 gap-4 lg:gap-10 mt-4 lg:mt-8 px-4 lg:content-padding pb-20 md:pb-4"
                     })
               ]
             });

--- a/src/helpers/Mattermost.bs.mjs
+++ b/src/helpers/Mattermost.bs.mjs
@@ -87,7 +87,10 @@ async function sendCreepsUpdate(bluePlayers, redPlayers, blueScore, redScore, po
   var redProbRounded = Math.round(redWinProb * 10.0) / 10.0;
   var blueProbStr = blueProbRounded.toString();
   var redProbStr = redProbRounded.toString();
-  var message = "### Nieuw potje geregistreerd!\n\n| Team | Spelers | Goals |\n| ---- | ------- | ----- |\n| Blauw | " + blueNames + " | " + blueScore.toString() + " |\n| Rood | " + redNames + " | " + redScore.toString() + " |\n\nIndividueel:\n- Blauw: " + blueIndividuals + "\n- Rood: " + redIndividuals + "\n\nOpenSkill winstkans (pre-game): Blauw " + blueProbStr + "% vs Rood " + redProbStr + "%\n";
+  var winnersProb;
+  winnersProb = winningTeam === "Blue" ? blueWinProb : redWinProb;
+  var sprokkelTitle = winnersProb > 80.0 ? "**SPROKKEL ALERT!** 🚨🚨🚨\n\n" : "";
+  var message = sprokkelTitle + ("### Nieuw potje geregistreerd!\n\n| Team | Spelers | Goals |\n| ---- | ------- | ----- |\n| Blauw | " + blueNames + " | " + blueScore.toString() + " |\n| Rood | " + redNames + " | " + redScore.toString() + " |\n\nIndividueel:\n- Blauw: " + blueIndividuals + "\n- Rood: " + redIndividuals + "\n\nOpenSkill winstkans (pre-game): Blauw " + blueProbStr + "% vs Rood " + redProbStr + "%\n");
   var promise = publishMessage(message);
   if (promise !== undefined) {
     await Caml_option.valFromOption(promise);

--- a/src/helpers/Mattermost.res
+++ b/src/helpers/Mattermost.res
@@ -116,7 +116,14 @@ let sendCreepsUpdate = async (
   let blueProbStr = blueProbRounded->Float.toString
   let redProbStr = redProbRounded->Float.toString
 
-  let message = `### Nieuw potje geregistreerd!
+  let winnersProb = switch winningTeam {
+  | Blue => blueWinProb
+  | Red => redWinProb
+  }
+
+  let sprokkelTitle = winnersProb > 80.0 ? "**SPROKKEL ALERT!** 🚨🚨🚨\n\n" : ""
+
+  let message = sprokkelTitle ++ `### Nieuw potje geregistreerd!
 
 | Team | Spelers | Goals |
 | ---- | ------- | ----- |


### PR DESCRIPTION
Add a "SPROKKEL ALERT!" banner to Mattermost game win messages when the winning team's pre-game probability exceeds 80%.

---
<a href="https://cursor.com/background-agent?bcId=bc-066ca656-ad6c-4191-ba2f-4e8c27ff1bfc">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-066ca656-ad6c-4191-ba2f-4e8c27ff1bfc">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

