### PR TITLE
Implement sprokkel message with gif

### DIFF
--- a/src/helpers/Mattermost.bs.mjs
+++ b/src/helpers/Mattermost.bs.mjs
@@ -89,9 +89,9 @@ async function sendCreepsUpdate(bluePlayers, redPlayers, blueScore, redScore, po
   var redProbStr = redProbRounded.toString();
   var winnersProb;
   winnersProb = winningTeam === "Blue" ? blueWinProb : redWinProb;
-  var reverseSprokkelImage = winnersProb < 20.0 ? "![](https://media0.giphy.com/media/v1.Y2lkPTc5MGI3NjExMDg4OXM2NDViaTU3Y21lZWFxam93YThyeXNkNzBkeGl0cTlucWhtYiZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/mcH0upG1TeEak/giphy.gif)\n\n" : "";
+  var reverseSprokkelImage = winnersProb <= 20.0 ? "![](https://media0.giphy.com/media/v1.Y2lkPTc5MGI3NjExMDg4OXM2NDViaTU3Y21lZWFxam93YThyeXNkNzBkeGl0cTlucWhtYiZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/mcH0upG1TeEak/giphy.gif)\n\n" : "";
   var sprokkelTitle = winnersProb > 80.0 ? "**SPROKKEL ALERT!** 🚨🚨🚨\n\n" : "";
-  var message = sprokkelTitle + reverseSprokkelImage + ("### Nieuw potje geregistreerd!\n \n | Team | Spelers | Goals |\n | ---- | ------- | ----- |\n | Blauw | " + blueNames + " | " + blueScore.toString() + " |\n | Rood | " + redNames + " | " + redScore.toString() + " |\n \n Individueel:\n - Blauw: " + blueIndividuals + "\n - Rood: " + redIndividuals + "\n \n OpenSkill winstkans (pre-game): Blauw " + blueProbStr + "% vs Rood " + redProbStr + "%\n ");
+  var message = sprokkelTitle + reverseSprokkelImage + ("### Nieuw potje geregistreerd!\n\n| Team | Spelers | Goals |\n| ---- | ------- | ----- |\n| Blauw | " + blueNames + " | " + blueScore.toString() + " |\n| Rood | " + redNames + " | " + redScore.toString() + " |\n\nIndividueel:\n- Blauw: " + blueIndividuals + "\n- Rood: " + redIndividuals + "\n\nOpenSkill winstkans (pre-game): Blauw " + blueProbStr + "% vs Rood " + redProbStr + "%\n");
   var promise = publishMessage(message);
   if (promise !== undefined) {
     await Caml_option.valFromOption(promise);

--- a/src/helpers/Mattermost.res
+++ b/src/helpers/Mattermost.res
@@ -121,23 +121,23 @@ let sendCreepsUpdate = async (
   | Red => redWinProb
   }
  
-  let reverseSprokkelImage = winnersProb < 20.0 ? "![](https://media0.giphy.com/media/v1.Y2lkPTc5MGI3NjExMDg4OXM2NDViaTU3Y21lZWFxam93YThyeXNkNzBkeGl0cTlucWhtYiZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/mcH0upG1TeEak/giphy.gif)\n\n" : ""
- 
+  let reverseSprokkelImage = winnersProb <= 20.0 ? "![](https://media0.giphy.com/media/v1.Y2lkPTc5MGI3NjExMDg4OXM2NDViaTU3Y21lZWFxam93YThyeXNkNzBkeGl0cTlucWhtYiZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/mcH0upG1TeEak/giphy.gif)\n\n" : ""
+  
   let sprokkelTitle = winnersProb > 80.0 ? "**SPROKKEL ALERT!** 🚨🚨🚨\n\n" : ""
- 
+  
   let message = (sprokkelTitle ++ reverseSprokkelImage) ++ `### Nieuw potje geregistreerd!
- 
- | Team | Spelers | Goals |
- | ---- | ------- | ----- |
- | Blauw | ${blueNames} | ${blueScore->Int.toString} |
- | Rood | ${redNames} | ${redScore->Int.toString} |
- 
- Individueel:
- - Blauw: ${blueIndividuals}
- - Rood: ${redIndividuals}
- 
- OpenSkill winstkans (pre-game): Blauw ${blueProbStr}% vs Rood ${redProbStr}%
- `
+
+| Team | Spelers | Goals |
+| ---- | ------- | ----- |
+| Blauw | ${blueNames} | ${blueScore->Int.toString} |
+| Rood | ${redNames} | ${redScore->Int.toString} |
+
+Individueel:
+- Blauw: ${blueIndividuals}
+- Rood: ${redIndividuals}
+
+OpenSkill winstkans (pre-game): Blauw ${blueProbStr}% vs Rood ${redProbStr}%
+`
 
   switch publishMessage(message) {
   | Some(promise) =>


### PR DESCRIPTION
Add a markdown image to Mattermost messages when the winning team's pre-game probability is below 20%.

---
<a href="https://cursor.com/background-agent?bcId=bc-83b1ab38-6051-46a0-b2f4-fb0aab5e1553">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-83b1ab38-6051-46a0-b2f4-fb0aab5e1553">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

