### PR TITLE
Add losing gif for high win chance

### DIFF
--- a/src/helpers/Mattermost.bs.mjs
+++ b/src/helpers/Mattermost.bs.mjs
@@ -89,8 +89,11 @@ async function sendCreepsUpdate(bluePlayers, redPlayers, blueScore, redScore, po
   var redProbStr = redProbRounded.toString();
   var winnersProb;
   winnersProb = winningTeam === "Blue" ? blueWinProb : redWinProb;
+  var losersProb;
+  losersProb = winningTeam === "Blue" ? redWinProb : blueWinProb;
   var sprokkelTitle = winnersProb > 80.0 ? "**SPROKKEL ALERT!** 🚨🚨🚨\n\n" : "";
-  var message = sprokkelTitle + ("### Nieuw potje geregistreerd!\n\n| Team | Spelers | Goals |\n| ---- | ------- | ----- |\n| Blauw | " + blueNames + " | " + blueScore.toString() + " |\n| Rood | " + redNames + " | " + redScore.toString() + " |\n\nIndividueel:\n- Blauw: " + blueIndividuals + "\n- Rood: " + redIndividuals + "\n\nOpenSkill winstkans (pre-game): Blauw " + blueProbStr + "% vs Rood " + redProbStr + "%\n");
+  var losingFavoriteImage = losersProb > 80.0 ? "\n\n![](https://media0.giphy.com/media/v1.Y2lkPTc5MGI3NjExMDg4OXM2NDViaTU3Y21lZWFxam93YThyeXNkNzBkeGl0cTlucWhtYiZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/mcH0upG1TeEak/giphy.gif)\n" : "";
+  var message = sprokkelTitle + ("### Nieuw potje geregistreerd!\n\n| Team | Spelers | Goals |\n| ---- | ------- | ----- |\n| Blauw | " + blueNames + " | " + blueScore.toString() + " |\n| Rood | " + redNames + " | " + redScore.toString() + " |\n\nIndividueel:\n- Blauw: " + blueIndividuals + "\n- Rood: " + redIndividuals + "\n\nOpenSkill winstkans (pre-game): Blauw " + blueProbStr + "% vs Rood " + redProbStr + "%\n") + losingFavoriteImage;
   var promise = publishMessage(message);
   if (promise !== undefined) {
     await Caml_option.valFromOption(promise);

--- a/src/helpers/Mattermost.res
+++ b/src/helpers/Mattermost.res
@@ -121,7 +121,17 @@ let sendCreepsUpdate = async (
   | Red => redWinProb
   }
 
+  let losersProb = switch winningTeam {
+  | Blue => redWinProb
+  | Red => blueWinProb
+  }
+
   let sprokkelTitle = winnersProb > 80.0 ? "**SPROKKEL ALERT!** 🚨🚨🚨\n\n" : ""
+
+  let losingFavoriteImage =
+    losersProb > 80.0
+      ? "\n\n![](https://media0.giphy.com/media/v1.Y2lkPTc5MGI3NjExMDg4OXM2NDViaTU3Y21lZWFxam93YThyeXNkNzBkeGl0cTlucWhtYiZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/mcH0upG1TeEak/giphy.gif)\n"
+      : ""
 
   let message = sprokkelTitle ++ `### Nieuw potje geregistreerd!
 
@@ -135,7 +145,7 @@ Individueel:
 - Rood: ${redIndividuals}
 
 OpenSkill winstkans (pre-game): Blauw ${blueProbStr}% vs Rood ${redProbStr}%
-`
+` ++ losingFavoriteImage
 
   switch publishMessage(message) {
   | Some(promise) =>


### PR DESCRIPTION
Add GIF to Mattermost message when a pre-game favorite team (80%+ win chance) loses.

---
<a href="https://cursor.com/background-agent?bcId=bc-77b13980-e658-461c-a127-aad7874c22da">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-77b13980-e658-461c-a127-aad7874c22da">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

