### PR TITLE
Fix FIFA scoring system

### DIFF
--- a/src/app/Logger.bs.mjs
+++ b/src/app/Logger.bs.mjs
@@ -43,6 +43,7 @@ function Logger(props) {
   var match$6 = React.useState(function () {
         return {};
       });
+  var setPerPlayerDeltas = match$6[1];
   var match$7 = React.useState(function () {
         return "Foosball";
       });
@@ -94,7 +95,7 @@ function Logger(props) {
                     redState: redState,
                     setRedState: setRedState,
                     setEarnedPoints: setEarnedPoints,
-                    setPerPlayerDeltas: match$6[1],
+                    setPerPlayerDeltas: setPerPlayerDeltas,
                     players: players,
                     gameMode: gameMode
                   });
@@ -114,7 +115,10 @@ function Logger(props) {
                     selectedUsers: selectedUsers,
                     setStep: setStep,
                     reset: reset,
+                    setRedState: setRedState,
+                    setBlueState: setBlueState,
                     setEarnedPoints: setEarnedPoints,
+                    setPerPlayerDeltas: setPerPlayerDeltas,
                     players: players,
                     gameMode: gameMode
                   });

--- a/src/app/Logger.res
+++ b/src/app/Logger.res
@@ -39,7 +39,7 @@ let make = (~players: array<Players.player>) => {
   | (ScoreForm, Games.Darts) =>
     <DartsGameModeStep selectedUsers setStep reset setEarnedPoints players gameMode />
   | (ScoreForm, Games.Fifa) =>
-    <FifaScoreStep selectedUsers setStep reset setEarnedPoints players gameMode />
+    <FifaScoreStep selectedUsers setStep reset setRedState setBlueState setEarnedPoints setPerPlayerDeltas players gameMode />
   | (ScoreForm, _) =>
     <ScoreStep
       selectedUsers

--- a/src/components/FifaScoreStep.resi
+++ b/src/components/FifaScoreStep.resi
@@ -1,0 +1,12 @@
+@react.component
+let make: (
+  ~selectedUsers: Belt.Map.String.t<Players.team>,
+  ~setStep: (LoggerStep.step => LoggerStep.step) => 'a,
+  ~reset: unit => unit,
+  ~setRedState: (int => int) => unit,
+  ~setBlueState: (int => int) => unit,
+  ~setEarnedPoints: (float => float) => unit,
+  ~setPerPlayerDeltas: (Js.Dict.t<int> => Js.Dict.t<int>) => unit,
+  ~players: array<Players.player>,
+  ~gameMode: Games.gameMode,
+) => React.element

--- a/src/helpers/Mattermost.res
+++ b/src/helpers/Mattermost.res
@@ -198,7 +198,7 @@ Game mode: ${mode}
 }
 
 let sendDailyUpdate = async () => {
-  let overview = await Summary.getDailyOverview("Daily")
+  let overview = await Summary.getDailyOverview(Daily)
   let overviewArray =
     overview
     ->Map.values


### PR DESCRIPTION
## Summary

- **Confirmation screen always showed Blue/Yellow as winners** — FifaScoreStep never passed scores to the parent, so `winnerTeam` was always Blue. Now passes `setRedState`/`setBlueState` props.
- **Score showed raw OpenSkill delta (~2.5) instead of scaled value (~150)** — Now uses `OpenSkillRating.toDisplayDelta` like foosball does.
- **No per-player deltas on confirmation** — Now populates `perPlayerDeltas` dict with display-scaled deltas for all players.
- **Mattermost notification showed stale rating changes** — Was using pre-calculation player objects. Now passes post-OpenSkill updated players.
- **Admin "Recalculate stats" ignored FIFA games** — Added FIFA game replay loop to `recalculateStats`, including field resets and OpenSkill recalculation.
- **Pre-existing bug**: Fixed `Mattermost.sendDailyUpdate` passing `"Daily"` string instead of `Daily` variant.

## Test plan

- [ ] Play a FIFA game where Red wins — confirm the confirmation screen shows Red as winners (not Blue)
- [ ] Verify the confirmation score is in the ~150 range (not ~2-3)
- [ ] Verify per-player score deltas appear on the confirmation screen
- [ ] Check Mattermost notification shows correct rating changes for the current game
- [ ] Run "Recalculate scores & stats" in admin and verify FIFA leaderboard data is preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)