### PR TITLE
fix: Fix FifaGames.fetchAllGames returning empty array

### DIFF
--- a/src/helpers/FifaGames.bs.mjs
+++ b/src/helpers/FifaGames.bs.mjs
@@ -3,7 +3,6 @@
 import * as React from "react";
 import * as Schema from "./Schema.bs.mjs";
 import * as Database from "./Database.bs.mjs";
-import * as Core__Array from "@rescript/core/src/Core__Array.bs.mjs";
 import * as RescriptCore from "@rescript/core/src/RescriptCore.bs.mjs";
 import * as Database$1 from "firebase/database";
 
@@ -38,17 +37,20 @@ function addFifaGame(fifaGame) {
 
 async function fetchAllGames() {
   var games = await Database$1.get(Database$1.query(Database$1.ref(Database.database, "fifaGames"), Database$1.orderByChild("date")));
-  return Core__Array.filterMap(games, (function (snap) {
-                var val = snap.val();
-                if (val == null) {
-                  return ;
-                }
-                var val$1 = Schema.parseWith(val, fifaGameSchema);
-                if (val$1.TAG === "Ok") {
-                  return val$1._0;
-                }
-                console.log(val$1._0);
-              }));
+  var orderedGames = [];
+  games.forEach(function (snap) {
+        var val = snap.val();
+        if (val == null) {
+          return ;
+        }
+        var val$1 = Schema.parseWith(val, fifaGameSchema);
+        if (val$1.TAG === "Ok") {
+          orderedGames.push(val$1._0);
+          return ;
+        }
+        console.log(val$1._0);
+      });
+  return orderedGames;
 }
 
 function removeGame(gameKey) {

--- a/src/helpers/FifaGames.res
+++ b/src/helpers/FifaGames.res
@@ -40,19 +40,19 @@ let fetchAllGames = async () => {
       Firebase.Database.orderByChild("date"),
     )->Firebase.Database.get
 
-  snapshotToArray(games)->Array.filterMap(snap => {
+  let orderedGames = []
+  Array.forEach(snapshotToArray(games), snap => {
     switch snap->Firebase.Database.Snapshot.val->Nullable.toOption {
     | Some(val) =>
       switch val->Schema.parseWith(fifaGameSchema) {
-      | Ok(val) => Some(val)
-      | Error(e) => {
-          Js.log(e)
-          None
-        }
+      | Ok(val) => orderedGames->Array.push(val)
+      | Error(e) => Js.log(e)
       }
-    | None => None
+    | None => ()
     }
   })
+
+  orderedGames
 }
 
 let removeGame = gameKey => {


### PR DESCRIPTION
FifaGames used Array.filterMap on a Firebase DataSnapshot, which relies on .length (absent on DataSnapshot). Games and DartsGames use Array.forEach + push, which delegates to DataSnapshot's own .forEach() method. This caused recalculateStats to find 0 FIFA games and reset all FIFA stats to zero.